### PR TITLE
[Refactor] 응답값에 근거 레벨 추가

### DIFF
--- a/app/ai/llm_backend.py
+++ b/app/ai/llm_backend.py
@@ -300,7 +300,7 @@ FEW_SHOT_EXAMPLES = """
 - KPI 10(45): 운영·모니터링·장애 경험 없음 → 하
 """
 
-def evaluate_resume_kpis(resume_text: str) -> Dict[int, int]:
+def evaluate_resume_kpis(resume_text: str) -> Dict[int, Dict[str, any]]:
     """
     이력서 텍스트를 LLM이 직접 평가하여 백엔드 KPI별 점수 산출.
     
@@ -311,7 +311,9 @@ def evaluate_resume_kpis(resume_text: str) -> Dict[int, int]:
         resume_text: 이력서/경력 텍스트
     
     Returns:
-        {kpi_id: 점수} (점수는 40~90 범위의 정수)
+        {kpi_id: {"score": 점수, "basis": 근거수준}}
+        - score: 40~90 범위의 정수
+        - basis: "explicit" | "inferred" | "none"
     """
     client = OpenAI(api_key=settings.OPENAI_API_KEY)
     
@@ -323,8 +325,21 @@ def evaluate_resume_kpis(resume_text: str) -> Dict[int, int]:
 {FEW_SHOT_EXAMPLES}
 
 ## 출력 형식
-반드시 JSON 형식으로만 응답해. 설명 없이 점수만 출력.
-{{"1": 점수, "2": 점수, ..., "10": 점수}}
+반드시 JSON 형식으로만 응답해. 각 KPI에 대해 점수와 근거 수준(basis)을 함께 출력.
+
+```json
+{{
+  "1": {{"score": 점수, "basis": "근거수준"}},
+  "2": {{"score": 점수, "basis": "근거수준"}},
+  ...
+  "10": {{"score": 점수, "basis": "근거수준"}}
+}}
+```
+
+## 근거 수준(basis) 판단 기준
+- **"explicit"**: 텍스트에 해당 KPI 관련 **구체적 경험/기술/성과가 명시**되어 있음
+- **"inferred"**: 직접 언급은 없지만 **맥락상 추론 가능** (예: Spring 사용 → Java 추론)
+- **"none"**: 해당 KPI 관련 **언급이 전혀 없음** → 점수는 40~50 범위
 
 ## 점수 부여 규칙 (중요!)
 - 상 수준: 75~90 범위에서 근거 강도에 따라 차등 (예: 강한 상=88, 보통 상=82, 약한 상=76)
@@ -349,7 +364,7 @@ def evaluate_resume_kpis(resume_text: str) -> Dict[int, int]:
 4. "문서로 정리", "협업" 추상적 언급만 → KPI 9는 중 상한
 5. "로그 정리", "기본 모니터링" → KPI 10은 중 상한
 
-JSON 형식으로 10개 KPI 점수를 출력해."""
+JSON 형식으로 10개 KPI의 점수(score)와 근거수준(basis)을 출력해."""
 
     try:
         response = client.chat.completions.create(
@@ -366,12 +381,28 @@ JSON 형식으로 10개 KPI 점수를 출력해."""
         scores = json.loads(result)
         
         # KPI ID를 int로 변환하고 범위 제한
-        return {
-            int(kpi_id): max(40, min(90, int(score))) 
-            for kpi_id, score in scores.items()
-        }
+        parsed_scores = {}
+        for kpi_id, data in scores.items():
+            # 새 형식: {"score": 점수, "basis": "근거수준"}
+            if isinstance(data, dict):
+                score = max(40, min(90, int(data.get("score", 45))))
+                basis = data.get("basis", "explicit")
+                # basis 값 검증
+                if basis not in ("explicit", "inferred", "none"):
+                    basis = "explicit"
+            else:
+                # 구 형식 호환: 점수만 있는 경우
+                score = max(40, min(90, int(data)))
+                basis = "explicit"
+            
+            parsed_scores[int(kpi_id)] = {
+                "score": score,
+                "basis": basis
+            }
+        
+        return parsed_scores
     
     except Exception as e:
         print(f"LLM 평가 오류: {e}")
         # 오류 시 기본값 반환
-        return {i: 45 for i in range(1, 11)}
+        return {i: {"score": 45, "basis": "none"} for i in range(1, 11)}

--- a/app/domains/kpi/scorer.py
+++ b/app/domains/kpi/scorer.py
@@ -30,7 +30,8 @@ def calculate_kpi_scores(
             kpi_id: {
                 "score": 점수 (40~90),
                 "level": "high/mid/low",
-                "kpi_name": KPI 이름
+                "kpi_name": KPI 이름,
+                "basis": "explicit/inferred/none"
             }
         }
     """
@@ -45,8 +46,17 @@ def calculate_kpi_scores(
         scores = evaluate_backend_kpis(resume_text)
     
     results = {}
-    for kpi_id, score in scores.items():
+    for kpi_id, data in scores.items():
         kpi_name = get_kpi_name(kpi_id, role=role)
+        
+        # 새 형식: {"score": 점수, "basis": "근거수준"}
+        if isinstance(data, dict):
+            score = data.get("score", 45)
+            basis = data.get("basis", "explicit")
+        else:
+            # 구 형식 호환: 점수만 있는 경우
+            score = data
+            basis = "explicit"
         
         # 레벨 결정 (75~90: 상, 55~70: 중, 40~50: 하)
         if score >= 75:
@@ -59,7 +69,8 @@ def calculate_kpi_scores(
         results[kpi_id] = {
             "score": score,
             "level": level,
-            "kpi_name": kpi_name
+            "kpi_name": kpi_name,
+            "basis": basis
         }
     
     return results

--- a/app/domains/kpi/service.py
+++ b/app/domains/kpi/service.py
@@ -40,7 +40,8 @@ def analyze_resume(resume_text: str, role: str = "backend") -> ResumeAnalysisRes
             kpi_id=kpi_id,
             kpi_name=data["kpi_name"],
             score=data["score"],
-            level=data["level"]
+            level=data["level"],
+            basis=data.get("basis", "explicit")
         )
         for kpi_id, data in kpi_scores.items()
     ]

--- a/app/schemas/kpi.py
+++ b/app/schemas/kpi.py
@@ -11,8 +11,12 @@ class KPIScoreResult(BaseModel):
     """KPI 점수 결과."""
     kpi_id: int
     kpi_name: str
-    score: int = Field(..., description="점수 (45/65/85)")
+    score: int = Field(..., description="점수 (40~90)")
     level: str = Field(..., description="high/mid/low")
+    basis: str = Field(
+        default="explicit", 
+        description="근거 수준: explicit(명시적 언급), inferred(간접 추론), none(언급 없음)"
+    )
 
 
 class ResumeAnalysisRequest(BaseModel):


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #21 

## 🔁 작업 내용
### KPI 평가 응답에 `basis` (근거 수준) 필드 추가

**목적**: 이력서에 해당 KPI 관련 근거가 부족한 경우 폴백 로직으로 분기할 수 있도록 근거 수준 정보 제공

**basis 값 정의**:
| 값 | 의미 | 처리 |
|----|------|------|
| `explicit` | 텍스트에 명시적 근거 있음 | 점수 그대로 사용 |
| `inferred` | 맥락상 추론 | 점수 사용 (낮은 신뢰) |
| `none` | 관련 언급 없음 | **폴백 로직 대상** |

**응답 예시**:
```json
{
  "kpi_id": 7,
  "kpi_name": "테스트·코드 품질",
  "score": 45,
  "level": "low",
  "basis": "none"
}
```

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)