### PR TITLE
[Feat] 백엔드 kpi 폴백로직 구현

### DIFF
--- a/app/domains/kpi/fallback_backend.py
+++ b/app/domains/kpi/fallback_backend.py
@@ -1,0 +1,152 @@
+"""
+백엔드 KPI 폴백 계산 모듈.
+
+설문 기반으로 KPI 점수를 계산하는 폴백 로직.
+이력서에 근거가 부족한 KPI(basis="none")에 대해 사용.
+"""
+from typing import Dict, List
+
+from app.domains.kpi.kpi_constants import BE_KPI_NAMES
+
+
+# 선택값(1~5) → 점수(0~100) 변환
+CHOICE_TO_SCORE = {
+    1: 0,
+    2: 25,
+    3: 50,
+    4: 75,
+    5: 100
+}
+
+# 질문별 KPI 가중치 매핑
+# Q_B1: 장애/문제 해결 상황
+Q_B1_WEIGHTS = {
+    10: 0.45,  # 운영·모니터링·장애 대응
+    6: 0.25,   # 성능·트래픽 처리 최적화
+    9: 0.20,   # 협업·문서화·의사결정 기록
+    4: 0.10,   # 아키텍처 설계
+}
+
+# Q_B2: 기능 설계 & 협업
+Q_B2_WEIGHTS = {
+    2: 0.35,   # REST API 설계·구현
+    3: 0.25,   # DB·데이터 모델링
+    4: 0.20,   # 아키텍처 설계
+    9: 0.20,   # 협업·문서화·의사결정 기록
+}
+
+# Q_B3: 배포·운영 환경 이해
+Q_B3_WEIGHTS = {
+    5: 0.45,   # 클라우드·DevOps 환경 이해
+    10: 0.25,  # 운영·모니터링·장애 대응
+    7: 0.15,   # 보안·인증·권한 처리
+    8: 0.15,   # 테스트·코드 품질 관리
+}
+
+# Q_B4: 품질 & 개선 문화
+Q_B4_WEIGHTS = {
+    8: 0.45,   # 테스트·코드 품질 관리
+    9: 0.25,   # 협업·문서화·의사결정 기록
+    1: 0.15,   # 백엔드 기술 역량
+    2: 0.15,   # REST API 설계·구현
+}
+
+# Q_B5: 문제 해결 방식
+Q_B5_WEIGHTS = {
+    6: 0.30,   # 성능·트래픽 처리 최적화
+    8: 0.25,   # 테스트·코드 품질 관리
+    4: 0.20,   # 아키텍처 설계
+    9: 0.15,   # 협업·문서화·의사결정 기록
+    3: 0.10,   # DB·데이터 모델링
+}
+
+
+def calculate_fallback_scores(
+    q_b1: int,
+    q_b2: int,
+    q_b3: int,
+    q_b4: int,
+    q_b5: int
+) -> Dict[int, Dict[str, any]]:
+    """
+    설문 응답 기반으로 KPI 점수 계산.
+    
+    Args:
+        q_b1~q_b5: 각 질문에 대한 응답 (1~5)
+    
+    Returns:
+        {
+            kpi_id: {
+                "score": 점수 (0~100),
+                "level": "high/mid/low",
+                "kpi_name": KPI 이름,
+                "source": "fallback"
+            }
+        }
+    """
+    # 선택값 → 점수 변환
+    scores = {
+        "q_b1": CHOICE_TO_SCORE.get(q_b1, 50),
+        "q_b2": CHOICE_TO_SCORE.get(q_b2, 50),
+        "q_b3": CHOICE_TO_SCORE.get(q_b3, 50),
+        "q_b4": CHOICE_TO_SCORE.get(q_b4, 50),
+        "q_b5": CHOICE_TO_SCORE.get(q_b5, 50),
+    }
+    
+    # KPI별 가중치 합산
+    # { kpi_id: [(점수, 가중치), ...] }
+    kpi_contributions: Dict[int, List[tuple]] = {i: [] for i in range(1, 11)}
+    
+    # Q_B1 기여
+    for kpi_id, weight in Q_B1_WEIGHTS.items():
+        kpi_contributions[kpi_id].append((scores["q_b1"], weight))
+    
+    # Q_B2 기여
+    for kpi_id, weight in Q_B2_WEIGHTS.items():
+        kpi_contributions[kpi_id].append((scores["q_b2"], weight))
+    
+    # Q_B3 기여
+    for kpi_id, weight in Q_B3_WEIGHTS.items():
+        kpi_contributions[kpi_id].append((scores["q_b3"], weight))
+    
+    # Q_B4 기여
+    for kpi_id, weight in Q_B4_WEIGHTS.items():
+        kpi_contributions[kpi_id].append((scores["q_b4"], weight))
+    
+    # Q_B5 기여
+    for kpi_id, weight in Q_B5_WEIGHTS.items():
+        kpi_contributions[kpi_id].append((scores["q_b5"], weight))
+    
+    # KPI별 최종 점수 계산 (가중 평균)
+    results = {}
+    for kpi_id in range(1, 11):
+        contributions = kpi_contributions[kpi_id]
+        
+        if contributions:
+            # 가중 평균 계산
+            total_weight = sum(w for _, w in contributions)
+            weighted_sum = sum(s * w for s, w in contributions)
+            final_score = round(weighted_sum / total_weight) if total_weight > 0 else 50
+        else:
+            # 해당 KPI에 기여하는 질문이 없는 경우 (현재 설계상 없음)
+            final_score = 50
+        
+        # 0~100 범위 제한
+        final_score = max(0, min(100, final_score))
+        
+        # 레벨 결정 (75~100: 상, 50~74: 중, 0~49: 하)
+        if final_score >= 75:
+            level = "high"
+        elif final_score >= 50:
+            level = "mid"
+        else:
+            level = "low"
+        
+        results[kpi_id] = {
+            "score": final_score,
+            "level": level,
+            "kpi_name": BE_KPI_NAMES.get(kpi_id, f"KPI {kpi_id}"),
+            "source": "fallback"
+        }
+    
+    return results

--- a/app/schemas/kpi.py
+++ b/app/schemas/kpi.py
@@ -29,3 +29,29 @@ class ResumeAnalysisResponse(BaseModel):
     scores: List[KPIScoreResult] = Field(..., description="KPI별 점수 결과")
     strengths: List[int] = Field(default_factory=list, description="강점 KPI ID 리스트 (상위 3개)")
     weaknesses: List[int] = Field(default_factory=list, description="약점 KPI ID 리스트 (하위 3개)")
+
+
+# ===== 폴백 로직용 스키마 =====
+
+class BackendFallbackRequest(BaseModel):
+    """백엔드 폴백 평가 요청 (설문 기반)."""
+    q_b1: int = Field(..., ge=1, le=5, description="Q_B1: 장애/문제 해결 (1~5)")
+    q_b2: int = Field(..., ge=1, le=5, description="Q_B2: 기능 설계 & 협업 (1~5)")
+    q_b3: int = Field(..., ge=1, le=5, description="Q_B3: 배포·운영 환경 (1~5)")
+    q_b4: int = Field(..., ge=1, le=5, description="Q_B4: 품질 & 개선 문화 (1~5)")
+    q_b5: int = Field(..., ge=1, le=5, description="Q_B5: 문제 해결 방식 (1~5)")
+
+
+class FallbackKPIScore(BaseModel):
+    """폴백으로 계산된 KPI 점수."""
+    kpi_id: int
+    kpi_name: str
+    score: int = Field(..., description="점수 (0~100, 가중 평균)")
+    level: str = Field(..., description="high/mid/low")
+    source: str = Field(default="fallback", description="점수 출처 (fallback)")
+
+
+class BackendFallbackResponse(BaseModel):
+    """백엔드 폴백 평가 응답."""
+    scores: List[FallbackKPIScore] = Field(..., description="폴백으로 계산된 KPI 점수")
+    raw_inputs: dict = Field(..., description="원본 입력값 (Q_B1~Q_B5)")


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #23 

## 🔁 작업 내용

### 백엔드 KPI 폴백 평가 API 구현

**목적**: 이력서에 근거가 부족한 KPI(`basis="none"`)에 대해 설문 기반으로 점수를 계산하는 폴백 로직 제공

**엔드포인트**: `POST /api/kpi/fallback/backend`

---

### 설문 구조 (Q_B1~Q_B5)

| 질문 | 내용 | 연관 KPI |
|------|------|----------|
| Q_B1 | 장애/문제 해결 경험 | 운영, 성능, 협업, 아키텍처 |
| Q_B2 | 기능 설계 & 협업 | REST, DB, 아키텍처, 협업 |
| Q_B3 | 배포·운영 환경 이해 | DevOps, 운영, 보안, 테스트 |
| Q_B4 | 품질 & 개선 문화 | 테스트, 협업, 언어, REST |
| Q_B5 | 문제 해결 방식 | 성능, 테스트, 아키텍처, 협업, DB |

### 점수 변환
| 선택 | 의미 | 점수 |
|------|------|------|
| 1 | 전혀 아니다 | 0 |
| 2 | 조금 했다 | 25 |
| 3 | 보통이다 | 50 |
| 4 | 꽤 했다 | 75 |
| 5 | 매우 그렇다 | 100 |

---

### API 사용 예시

**요청**:
```json
{
  "q_b1": 4,
  "q_b2": 3,
  "q_b3": 2,
  "q_b4": 4,
  "q_b5": 3
}
```

**응답**:
```json
{
  "scores": [
    {"kpi_id": 1, "kpi_name": "백엔드 기술 역량", "score": 75, "level": "high", "source": "fallback"},
    {"kpi_id": 2, "kpi_name": "REST API 설계·구현", "score": 56, "level": "mid", "source": "fallback"},
    ...
  ],
  "raw_inputs": {"q_b1": 4, "q_b2": 3, "q_b3": 2, "q_b4": 4, "q_b5": 3}
}
```

## 📸 스크린샷 (Optional)
<img width="737" height="646" alt="스크린샷 2026-02-02 오후 8 47 55" src="https://github.com/user-attachments/assets/7453b7e1-c29b-43a8-bc92-e20efc8ff58d" />


## 👀 기타 더 이야기해볼 점 (Optional)

**메인 서버 연동 흐름**:
```
1. /api/kpi/analyze/backend 호출
2. 응답에서 basis="none"인 KPI 확인
3. 사용자에게 Q_B1~Q_B5 설문 표시
4. /api/kpi/fallback/backend 호출
5. LLM 점수 + 폴백 점수 병합
```